### PR TITLE
feat: add LLM env config management API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,8 @@ celerybeat.pid
 
 # Environments
 .env
+dev.env
+prod.env
 .envrc
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Meeting Mood Tracker
 
 A FastAPI-based application that analyzes meeting transcripts to accurately identify conversation topics and overall participant moods. Built strictly with Specification-Driven Development (SDD) principles.
+
+## LLM Environment Config API
+
+- Endpoint: `GET /api/env/v1`
+- Reads env file by `APP_ENV`:
+  - `APP_ENV=dev` or unset -> `dev.env`
+  - `APP_ENV=prod` -> `prod.env`
+- Returns raw values:
+  - `LLM_API_KEY`
+  - `LLM_ENDPOINT`
+  - `LLM_MODEL`
+- Error behavior:
+  - `422` if required keys are missing
+  - `500` if env file is missing or `APP_ENV` is invalid
+
+Use `example.env` as the template. Keep `dev.env` and `prod.env` local only.

--- a/agent-progress.txt
+++ b/agent-progress.txt
@@ -23,3 +23,17 @@
   - `uv run python harness/runner/agent_runner.py --mode precommit` 통과
   - `uv run python harness/runner/agent_runner.py --mode full` 통과
   - `uv run python scripts/validate_capability_manifest.py` 통과
+---
+## [2026-03-27] LLM 설정/환경변수 관리 API 추가 (`GET /api/env/v1`)
+- **수행 내역**:
+  1. `app/config/llm_env.py`를 신설하여 `python-dotenv` 기반 env 파일 로더 구현 (`APP_ENV=dev|prod`, 기본값 `dev`).
+  2. `app/service/llm_config_service.py`를 신설하여 필수 키(`LLM_API_KEY`, `LLM_ENDPOINT`, `LLM_MODEL`) 검증 및 예외 도메인화(검증 실패/로딩 실패) 적용.
+  3. `app/types/llm_config.py` 응답 스키마와 `app/runtime/env_config.py` 라우트를 추가하고, `app/main.py`에 라우터 연결.
+  4. `tests/test_env_config.py`에 신규 5개 테스트를 추가하여 dev/prod 분기, 원문값 반환, 422/500 에러 경로를 검증.
+  5. `.gitignore`(`dev.env`, `prod.env`), `example.env`, `README.md`, `docs/DESIGN.md`, `docs/ARCHITECTURE.md`, `feature_list.json`을 동기화.
+  6. `pyproject.toml`, `uv.lock`에 `python-dotenv` 의존성 반영.
+- **검증 결과**:
+  - `uv run ruff format app/ tests/ docs/` 통과
+  - `uv run ruff check .` 통과
+  - `uv run pytest tests -v --maxfail=1 --tb=short` 통과 (18 passed)
+  - `uv run python harness/runner/agent_runner.py --mode full` 통과

--- a/app/config/llm_env.py
+++ b/app/config/llm_env.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+ENV_FILE_BY_APP_ENV: dict[str, str] = {
+    "dev": "dev.env",
+    "prod": "prod.env",
+}
+
+
+def get_project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_app_env(app_env_raw: str | None) -> str:
+    if app_env_raw is None or app_env_raw == "":
+        return "dev"
+
+    if app_env_raw not in ENV_FILE_BY_APP_ENV:
+        allowed = ", ".join(sorted(ENV_FILE_BY_APP_ENV.keys()))
+        raise ValueError(
+            f"APP_ENV must be one of [{allowed}], but got '{app_env_raw}'."
+        )
+
+    return app_env_raw
+
+
+def resolve_env_file_path(project_root: Path, app_env: str) -> Path:
+    env_file_name = ENV_FILE_BY_APP_ENV[app_env]
+    return project_root / env_file_name
+
+
+def load_env_file_values(
+    project_root: Path, app_env_raw: str | None
+) -> dict[str, str | None]:
+    app_env = resolve_app_env(app_env_raw=app_env_raw)
+    env_file_path = resolve_env_file_path(project_root=project_root, app_env=app_env)
+
+    if not env_file_path.exists():
+        raise FileNotFoundError(f"Environment file not found: {env_file_path}")
+
+    loaded = dotenv_values(env_file_path)
+    return {str(key): value for key, value in loaded.items()}

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
 from fastapi import FastAPI
 
 from app.runtime.analyze import router as analyze_router
+from app.runtime.env_config import router as env_config_router
 
 app = FastAPI(title="MeetingMoodTracker")
 
 app.include_router(analyze_router, prefix="/api/v1")
+app.include_router(env_config_router)

--- a/app/runtime/env_config.py
+++ b/app/runtime/env_config.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, HTTPException
+
+from app.service.llm_config_service import (
+    LlmConfigLoadError,
+    LlmConfigValidationError,
+    get_llm_config,
+)
+from app.types.llm_config import LlmConfigResponse
+
+router = APIRouter()
+
+
+@router.get("/api/env/v1", response_model=LlmConfigResponse)
+def get_llm_environment_config() -> LlmConfigResponse:
+    try:
+        return get_llm_config()
+    except LlmConfigValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "Required LLM configuration key is missing.",
+                "missing_keys": exc.missing_keys,
+            },
+        ) from exc
+    except LlmConfigLoadError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/app/service/llm_config_service.py
+++ b/app/service/llm_config_service.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+from typing import Mapping
+
+from app.config.llm_env import get_project_root, load_env_file_values
+from app.types.llm_config import LlmConfigResponse
+
+REQUIRED_LLM_KEYS: tuple[str, str, str] = (
+    "LLM_API_KEY",
+    "LLM_ENDPOINT",
+    "LLM_MODEL",
+)
+
+
+class LlmConfigLoadError(Exception):
+    pass
+
+
+class LlmConfigValidationError(Exception):
+    def __init__(self, missing_keys: list[str]) -> None:
+        self.missing_keys = missing_keys
+        missing_text = ", ".join(missing_keys)
+        super().__init__(f"Missing required LLM keys: {missing_text}")
+
+
+def _extract_required_values(values: Mapping[str, str | None]) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    missing_keys: list[str] = []
+
+    for key in REQUIRED_LLM_KEYS:
+        value = values.get(key)
+        if value is None or value.strip() == "":
+            missing_keys.append(key)
+            continue
+        resolved[key] = value
+
+    if missing_keys:
+        raise LlmConfigValidationError(missing_keys=missing_keys)
+
+    return resolved
+
+
+def get_llm_config(
+    app_env_raw: str | None = None, project_root: Path | None = None
+) -> LlmConfigResponse:
+    env_value = app_env_raw if app_env_raw is not None else os.getenv("APP_ENV")
+    base_dir = project_root if project_root is not None else get_project_root()
+
+    try:
+        loaded_values = load_env_file_values(
+            project_root=base_dir,
+            app_env_raw=env_value,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        raise LlmConfigLoadError(str(exc)) from exc
+
+    required_values = _extract_required_values(values=loaded_values)
+    return LlmConfigResponse(**required_values)

--- a/app/types/llm_config.py
+++ b/app/types/llm_config.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class LlmConfigResponse(BaseModel):
+    LLM_API_KEY: str
+    LLM_ENDPOINT: str
+    LLM_MODEL: str

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,12 @@ MeetingMoodTracker는 인간의 언어로 된 룰이 아닌 "기계적인 하네
 - **`app/ui/`**: (최상위) 프론트엔드 연동 및 템플릿 서빙
 - **`app/main.py`**: 단지 서버를 구동(Boot)하는 진입점 모듈
 
+### LLM Config Read Flow
+
+- `app/runtime/env_config.py`의 `GET /api/env/v1` 라우트가 진입점입니다.
+- `app/service/llm_config_service.py`가 필수 키(`LLM_API_KEY`, `LLM_ENDPOINT`, `LLM_MODEL`) 검증 및 오류 분기(422/500)를 담당합니다.
+- `app/config/llm_env.py`가 `APP_ENV(dev|prod)` 기준 env 파일(`dev.env`/`prod.env`)을 선택하고 로드합니다.
+
 ## Dependency Rules (단방향 헌법)
 
 - 모듈 의존성은 반드시 **`Types <- Config <- Repo <- Service <- Runtime <- UI`** 의 단방향 논리로만 흘러야 합니다.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -15,3 +15,10 @@
 - `POST /api/v1/analyze`:
   - Request: `MeetingAnalyzeRequest` (meeting_id, transcript_text)
   - Response: `MeetingAnalyzeResponse` (overall_mood, topics, severity)
+- `GET /api/env/v1`:
+  - Purpose: LLM 연동에 필요한 환경설정 조회 (read-only)
+  - Source: `APP_ENV` 기준 `dev.env` 또는 `prod.env` 파일
+  - Response: `LLM_API_KEY`, `LLM_ENDPOINT`, `LLM_MODEL` 원문 값
+  - Errors:
+    - `422`: 필수 키 누락
+    - `500`: env 파일 누락 또는 `APP_ENV` 값 오류

--- a/example.env
+++ b/example.env
@@ -1,0 +1,3 @@
+LLM_API_KEY=your-api-key
+LLM_ENDPOINT=https://your-endpoint.example.com
+LLM_MODEL=gpt-5.4

--- a/feature_list.json
+++ b/feature_list.json
@@ -31,6 +31,12 @@
       "name": "Mood and Severity Analysis",
       "description": "Assess severity (1-10) and mood parameters (constructive, tense, etc.) from transcript.",
       "passes": false
+    },
+    {
+      "id": "feat_config_llm_env_management",
+      "name": "LLM Config and Environment File Management",
+      "description": "Provide read-only API to load LLM config from dev/prod env files and validate required keys.",
+      "passes": false
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic",
     "pytest",
     "httpx",
+    "python-dotenv>=1.2.2",
 ]
 
 [build-system]

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import app.service.llm_config_service as llm_config_service
+from app.main import app
+
+client = TestClient(app)
+
+
+def _write_env_file(
+    base_dir: Path,
+    file_name: str,
+    values: dict[str, str],
+) -> None:
+    lines = [f"{key}={value}" for key, value in values.items()]
+    (base_dir / file_name).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_get_llm_config_uses_dev_file_when_app_env_is_unset(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _write_env_file(
+        base_dir=tmp_path,
+        file_name="dev.env",
+        values={
+            "LLM_API_KEY": "dev-key-001",
+            "LLM_ENDPOINT": "https://dev.endpoint",
+            "LLM_MODEL": "gpt-dev",
+        },
+    )
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setattr(llm_config_service, "get_project_root", lambda: tmp_path)
+
+    response = client.get("/api/env/v1")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "LLM_API_KEY": "dev-key-001",
+        "LLM_ENDPOINT": "https://dev.endpoint",
+        "LLM_MODEL": "gpt-dev",
+    }
+
+
+def test_get_llm_config_uses_prod_file_when_app_env_is_prod(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _write_env_file(
+        base_dir=tmp_path,
+        file_name="prod.env",
+        values={
+            "LLM_API_KEY": "prod-key-999",
+            "LLM_ENDPOINT": "https://prod.endpoint",
+            "LLM_MODEL": "gpt-prod",
+        },
+    )
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setattr(llm_config_service, "get_project_root", lambda: tmp_path)
+
+    response = client.get("/api/env/v1")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "LLM_API_KEY": "prod-key-999",
+        "LLM_ENDPOINT": "https://prod.endpoint",
+        "LLM_MODEL": "gpt-prod",
+    }
+
+
+def test_get_llm_config_returns_422_when_required_keys_are_missing(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _write_env_file(
+        base_dir=tmp_path,
+        file_name="dev.env",
+        values={
+            "LLM_API_KEY": "dev-key-001",
+            "LLM_ENDPOINT": "https://dev.endpoint",
+        },
+    )
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setattr(llm_config_service, "get_project_root", lambda: tmp_path)
+
+    response = client.get("/api/env/v1")
+
+    assert response.status_code == 422
+    assert "missing_keys" in response.json()["detail"]
+    assert response.json()["detail"]["missing_keys"] == ["LLM_MODEL"]
+
+
+def test_get_llm_config_returns_500_when_target_env_file_is_missing(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setattr(llm_config_service, "get_project_root", lambda: tmp_path)
+
+    response = client.get("/api/env/v1")
+
+    assert response.status_code == 500
+    assert "Environment file not found" in response.json()["detail"]
+
+
+def test_get_llm_config_returns_500_when_app_env_is_invalid(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "stage")
+    monkeypatch.setattr(llm_config_service, "get_project_root", lambda: tmp_path)
+
+    response = client.get("/api/env/v1")
+
+    assert response.status_code == 500
+    assert "APP_ENV must be one of [dev, prod]" in response.json()["detail"]

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pytest" },
+    { name = "python-dotenv" },
     { name = "uvicorn" },
 ]
 
@@ -157,6 +158,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pytest" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "uvicorn" },
 ]
 
@@ -290,6 +292,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add read-only GET /api/env/v1 endpoint to expose LLM env config
- load env file by APP_ENV (dev default, prod supported) using python-dotenv
- validate required keys (LLM_API_KEY, LLM_ENDPOINT, LLM_MODEL) and map errors to 422/500
- add env config tests and update docs/feature list/progress log

## Validation
- uv run ruff check .
- uv run pytest tests -v --maxfail=1 --tb=short
- uv run python harness/runner/agent_runner.py --mode full
