### PR TITLE
feat(docker): add /healthz liveness endpoint and Docker HEALTHCHECK

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A FastAPI-based application that analyzes meeting transcripts to identify discus
   - `MEETING_MOOD_TRACKER_SUBMODULE_PATH` (기본값: `./MeetingMoodTracker`)
 - 상위 리포지토리에서 사용할 때는 템플릿 내용을 상위 `docker-compose.yml`에 반영하거나 include하여 사용합니다.
 - 템플릿은 `APP_ENV` 값에 맞춰 `${APP_ENV}.env`를 `env_file`과 컨테이너 내부 `/app/${APP_ENV}.env`에 함께 연결합니다.
+- API Docker 이미지는 `HEALTHCHECK`를 내장하며, Python 표준 라이브러리(`urllib`)로 `/healthz`를 주기적으로 점검합니다.
 
 대표 실행 예시(상위 리포지토리 루트 기준):
 
@@ -57,6 +58,7 @@ docker compose up --build
 
 검증:
 - 브라우저에서 `http://localhost:${FASTAPI_SERVER_PORT}/docs` 접근
+- `http://localhost:${FASTAPI_SERVER_PORT}/healthz`가 `{"status":"ok"}`를 반환하는지 확인
 
 ## Turn Sentiment API
 
@@ -74,6 +76,13 @@ docker compose up --build
   - `label`
   - `confidence` (`0.0` - `1.0`)
   - `evidence`
+
+## Health Check API
+
+- Endpoint: `GET /healthz`
+- Purpose: 프로세스 응답성(liveness) 확인
+- Response fields:
+  - `status` (`"ok"`)
 
 ## LLM Environment Config API
 

--- a/agent-progress.txt
+++ b/agent-progress.txt
@@ -2,6 +2,27 @@
 새로운 에이전트 세션이 시작될 때 문맥을 신속히 파악하기 위한 로그입니다. 큰 작업 주기가 끝날 때마다 에이전트가 직접 기록합니다.
 
 ---
+## [2026-04-01] Dockerize Health-Check 반영 (`GET /healthz` + Dockerfile `HEALTHCHECK`)
+- **수행 내역**:
+  1. 신규 상태 점검 API `GET /healthz`를 추가:
+     - 타입: `app/types/health.py` (`HealthzResponse`, `status="ok"`)
+     - 라우트: `app/runtime/health.py`
+     - 앱 등록: `app/main.py`
+  2. API 이미지에 Docker `HEALTHCHECK`를 추가:
+     - 파일: `docker/Dockerfile.api`
+     - 방식: Python 표준 라이브러리 `urllib`로 `http://127.0.0.1:${FASTAPI_SERVER_PORT:-8000}/healthz` 호출
+     - 파라미터: `interval=30s`, `timeout=5s`, `start-period=20s`, `retries=3`
+  3. 신규 테스트 `tests/test_healthz.py`를 추가해 `/healthz` 응답 계약(`200`, `{\"status\":\"ok\"}`)을 검증.
+  4. 문서 동기화:
+     - `README.md`: Docker health-check 설명과 `/healthz` 검증 절차 추가
+     - `docs/DESIGN.md`: 핵심 API 목록에 `GET /healthz` 추가
+     - `docs/ARCHITECTURE.md`: Health Check Flow 섹션 추가
+- **검증 결과**:
+  - `.venv/bin/python -m ruff check .` 통과
+  - `.venv/bin/python -m pytest tests/test_healthz.py tests/test_sentiment_turn.py tests/test_env_config.py -q` 통과 (10 passed)
+  - `.venv/bin/python harness/runner/agent_runner.py --mode full` 통과 (56 passed)
+  - 로컬 환경에 `docker` 바이너리가 없어 컨테이너 런타임 health 상태(`docker ps`의 health) 직접 검증은 미실행
+---
 ## [2026-03-30] Subagent 병렬 점검 반영 (Docker env 경로 정합 + API 버전 계약 보강)
 - **수행 내역**:
   1. 코드리뷰 에이전트/서버 개발 에이전트/Docker 전문가 대체 에이전트를 병렬로 구성해 PR #11 변경분을 재점검.

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 
 from app.runtime.analyze import router as analyze_router
 from app.runtime.env_config import router as env_config_router
+from app.runtime.health import router as health_router
 from app.runtime.sentiment import router as sentiment_router
 
 app = FastAPI(title="MeetingMoodTracker")
@@ -11,3 +12,4 @@ app = FastAPI(title="MeetingMoodTracker")
 app.include_router(analyze_router, prefix="/api/v1")
 app.include_router(env_config_router)
 app.include_router(sentiment_router)
+app.include_router(health_router)

--- a/app/runtime/health.py
+++ b/app/runtime/health.py
@@ -1,0 +1,13 @@
+"""프로세스 liveness 확인용 healthz API 라우트."""
+
+from fastapi import APIRouter
+
+from app.types.health import HealthzResponse
+
+router = APIRouter()
+
+
+@router.get("/healthz", response_model=HealthzResponse)
+def healthz() -> HealthzResponse:
+    """애플리케이션 프로세스 응답성을 확인하는 healthz 엔드포인트."""
+    return HealthzResponse()

--- a/app/types/health.py
+++ b/app/types/health.py
@@ -1,0 +1,11 @@
+"""서비스 상태 점검(healthz) 응답 타입 정의."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class HealthzResponse(BaseModel):
+    """프로세스 liveness 확인용 healthz 응답 스키마."""
+
+    status: Literal["ok"] = "ok"

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -20,4 +20,7 @@ COPY app ./app
 
 EXPOSE 8000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD python -c "import os,sys,urllib.request; port=os.environ.get('FASTAPI_SERVER_PORT','8000'); response=urllib.request.urlopen(f'http://127.0.0.1:{port}/healthz', timeout=4); sys.exit(0 if response.getcode()==200 else 1)"
+
 CMD ["/bin/sh", "-c", "uv run uvicorn app.main:app --host 0.0.0.0 --port ${FASTAPI_SERVER_PORT:-8000}"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,6 +36,12 @@ MeetingMoodTracker는 인간의 언어로 된 룰이 아닌 "기계적인 하네
   - API Version: `LLM_API_VERSION` 우선, 없으면 `LLM_MODEL_VERSION`, 둘 다 없으면 기본값 `2025-04-01-preview`
 - 분류 결과는 `app/types/sentiment.py`의 `TurnSentimentResponse`로 검증 후 반환됩니다.
 
+### Health Check Flow
+
+- `app/runtime/health.py`의 `GET /healthz`가 프로세스 응답성 확인 진입점입니다.
+- 응답은 `app/types/health.py`의 `HealthzResponse`로 고정되며, 현재 상태(`status="ok"`)만 반환합니다.
+- `docker/Dockerfile.api`는 이미지 레벨 `HEALTHCHECK`를 내장하고, Python `urllib`로 `http://127.0.0.1:${FASTAPI_SERVER_PORT:-8000}/healthz`를 주기적으로 호출합니다.
+
 ### Analyze Inspect Flow (REST + SSE)
 
 - `app/service/analyze_service.py`의 `run_analyze_pipeline`이 `/analyze`, `/analyze/inspect`, `/analyze/inspect/stream`이 공통으로 호출하는 단일 알고리즘 메서드입니다.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -32,6 +32,9 @@
   - 특이사항:
     - 한국어 중심 텍스트 + 영어 혼합 입력(code-switching) 대응
     - OpenAI SDK(Azure OpenAI) + `json_schema` 구조화 출력 강제
+- `GET /healthz`:
+  - Purpose: 컨테이너/런타임에서 애플리케이션 프로세스 응답성(liveness) 확인
+  - Response: `HealthzResponse` (`status="ok"`)
 - `GET /api/env/v1`:
   - Purpose: LLM 연동에 필요한 환경설정 조회 (read-only)
   - Source: `APP_ENV` 기준 `dev.env` 또는 `prod.env` 파일

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_healthz_returns_ok_status() -> None:
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## 요약
- API liveness endpoint `GET /healthz`를 추가했습니다.
- `HealthzResponse` 타입(`app/types`) 기반으로 응답 계약을 고정했습니다.
- `docker/Dockerfile.api`에 이미지 레벨 `HEALTHCHECK`를 추가했습니다.
  - `urllib`를 사용해 `http://127.0.0.1:${FASTAPI_SERVER_PORT:-8000}/healthz` 점검
  - `interval=30s`, `timeout=5s`, `start-period=20s`, `retries=3`
- 문서(README, DESIGN, ARCHITECTURE)와 테스트를 동기화했습니다.

## 테스트
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest tests/test_healthz.py tests/test_sentiment_turn.py tests/test_env_config.py -q`
- `.venv/bin/python harness/runner/agent_runner.py --mode full`

## 이슈 연계
- #12의 healthcheck 항목에 해당하는 변경입니다. (이슈 전체 완료는 별도 작업 필요)
