### PR TITLE
chore: finalize feat_ops_dockerize issue state

### DIFF
--- a/agent-progress.txt
+++ b/agent-progress.txt
@@ -2,6 +2,15 @@
 새로운 에이전트 세션이 시작될 때 문맥을 신속히 파악하기 위한 로그입니다. 큰 작업 주기가 끝날 때마다 에이전트가 직접 기록합니다.
 
 ---
+## [2026-04-01] Dockerize 이슈 #12 종료 동기화 (`feat_ops_dockerize`)
+- **수행 내역**:
+  1. `feature_list.json`의 `feat_ops_dockerize.passes` 값을 `true`로 전환.
+  2. `scripts/sync_feature_issues.py --sync-state --write-feature-file --apply`를 실행해 GitHub Issue #12 상태를 `closed`로 동기화.
+  3. feature 메타데이터(`github_issue.state`, `synced_at`)를 최신 상태로 기록.
+- **검증 결과**:
+  - `gh issue view 12 --json state` 기준 `CLOSED` 확인
+  - `.venv/bin/python -m pytest tests/test_sync_feature_issues.py -q` 통과 (6 passed)
+---
 ## [2026-04-01] Dockerize Health-Check 반영 (`GET /healthz` + Dockerfile `HEALTHCHECK`)
 - **수행 내역**:
   1. 신규 상태 점검 API `GET /healthz`를 추가:

--- a/feature_list.json
+++ b/feature_list.json
@@ -90,7 +90,7 @@
       "id": "feat_ops_dockerize",
       "name": "Dockerize Runtime Baseline",
       "description": "FastAPI API 서버와 Streamlit 테스트 UI를 Docker 환경에서 동일하게 실행할 수 있도록 컨테이너 표준 실행 경로를 구축합니다.",
-      "passes": false,
+      "passes": true,
       "issue_rule": {
         "objective": "개발자 로컬/CI에서 동일한 컨테이너 실행 결과를 재현한다.",
         "in_scope": [
@@ -116,6 +116,12 @@
           "로컬 개발자가 README만으로 Docker 실행 가능",
           "하네스/pytest 실행 경로가 Docker 사용 시에도 깨지지 않음"
         ]
+      },
+      "github_issue": {
+        "number": 12,
+        "url": "https://github.com/pko89403/MeetingMoodTracker/issues/12",
+        "state": "closed",
+        "synced_at": "2026-04-01T02:14:44+00:00"
       }
     }
   ]


### PR DESCRIPTION
## 요약
- `feature_list.json`의 `feat_ops_dockerize.passes`를 `true`로 전환했습니다.
- feature-issue 동기화 스크립트를 apply 모드로 실행해 이슈 #12를 `closed`로 동기화했습니다.
- 동기화 결과(`github_issue.state`, `synced_at`)를 `feature_list.json`에 반영했습니다.
- `agent-progress.txt`에 이슈 종료 동기화 로그를 기록했습니다.

## 검증
- `gh issue view 12 --json state` -> `CLOSED`
- `.venv/bin/python -m pytest tests/test_sync_feature_issues.py -q`

## 이슈
- closes #12
