### PR TITLE
feat: implement rule-base rubric calculation pipeline (issue #21)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from app.runtime.analyze import router as analyze_router
 from app.runtime.emotion import router as emotion_router
 from app.runtime.env_config import router as env_config_router
 from app.runtime.health import router as health_router
+from app.runtime.rubric import router as rubric_router
 from app.runtime.sentiment import router as sentiment_router
 
 app = FastAPI(title="MeetingMoodTracker")
@@ -14,4 +15,5 @@ app.include_router(analyze_router, prefix="/api/v1")
 app.include_router(emotion_router)
 app.include_router(env_config_router)
 app.include_router(sentiment_router)
+app.include_router(rubric_router)
 app.include_router(health_router)

--- a/app/runtime/rubric.py
+++ b/app/runtime/rubric.py
@@ -1,0 +1,45 @@
+"""루브릭 지수 산출 API 런타임 라우트."""
+
+from fastapi import APIRouter
+
+from app.service.analyze_service import calculate_final_rubrics
+from app.types.emotion import (
+    EmotionConfidenceValue,
+    EmotionScores,
+    TurnEmotionResponse,
+)
+from app.types.rubric import RubricCalculateRequest, RubricCalculateResponse
+
+router = APIRouter(prefix="/api/v1/rubric", tags=["rubric"])
+
+
+@router.post("/calculate", response_model=RubricCalculateResponse)
+async def calculate_rubric_endpoint(
+    request: RubricCalculateRequest,
+) -> RubricCalculateResponse:
+    """추출된 지표들을 기반으로 루브릭 지수(주도성, 효율성, 결속력)를 산출한다."""
+
+    # calculate_final_rubrics는 TurnEmotionResponse 객체를 기대하므로 변환
+    # (실제 계산에는 meeting_signals만 사용되므로 더미 데이터를 포함하여 생성)
+    dummy_emotions = EmotionScores(
+        anger=EmotionConfidenceValue(confidence=0),
+        joy=EmotionConfidenceValue(confidence=0),
+        sadness=EmotionConfidenceValue(confidence=0),
+        neutral=EmotionConfidenceValue(confidence=0),
+        anxiety=EmotionConfidenceValue(confidence=0),
+        frustration=EmotionConfidenceValue(confidence=0),
+        excitement=EmotionConfidenceValue(confidence=0),
+        confusion=EmotionConfidenceValue(confidence=0),
+    )
+
+    emotion_obj = TurnEmotionResponse(
+        emotions=dummy_emotions,
+        meeting_signals=request.meeting_signals,
+        emerging_emotions=[],
+    )
+
+    rubric = calculate_final_rubrics(
+        topics=request.topics, sentiment=request.sentiment, emotion=emotion_obj
+    )
+
+    return RubricCalculateResponse(rubric=rubric)

--- a/app/service/analyze_service.py
+++ b/app/service/analyze_service.py
@@ -29,6 +29,7 @@ from app.types.mood import (
     AnalyzeRequest,
     AnalyzeResponse,
     AnalyzeSentiment,
+    MeetingRubrics,
     SentimentConfidence,
 )
 
@@ -195,6 +196,45 @@ async def analyze_emotion_with_llm(
         emotions=base_emotions,
         meeting_signals=meeting_signals,
         emerging_emotions=emerging_emotions,
+    )
+
+
+def calculate_final_rubrics(
+    topics: list[str],
+    sentiment: AnalyzeSentiment,
+    emotion: TurnEmotionResponse,
+) -> MeetingRubrics:
+    """추출된 모든 지표(Topic, Sentiment, Emotion)를 조합하여 최종 루브릭 지수를 산출한다."""
+    # 회의 시그널 데이터 확보
+    sig = emotion.meeting_signals
+    e = sig.engagement.confidence
+    t = sig.tension.confidence
+    c = sig.clarity.confidence
+    a = sig.alignment.confidence
+    u = sig.urgency.confidence
+
+    # 1. Dominance (주도성): 대화 주도권 및 영향력
+    # 로직: 기본 시그널 조합 + Sentiment의 Neutral이 낮을수록 주도적 분석으로 판단
+    base_dominance = e * 0.35 + t * 0.25 + c * 0.20 + a * 0.10 + u * 0.10
+    sentiment_bonus = (100.0 - sentiment.neutral.confidence) * 0.1
+    final_dominance = base_dominance + sentiment_bonus
+
+    # 2. Efficiency (효율성): 결론 도출 및 논의 생산성
+    # 로직: Clarity/Urgency 조합 + Topic이 명확히 추출되었는지(갯수) 반영
+    base_efficiency = c * 0.50 + u * 0.30 + e * 0.20
+    topic_bonus = min(len(topics) * 5.0, 15.0)  # 주제가 구체적일수록 보너스
+    final_efficiency = base_efficiency + topic_bonus
+
+    # 3. Cohesion (결속력): 팀 내 합의 및 긍정적 에너지
+    # 로직: Alignment/Engagement 조합 + Positive Sentiment 가중치 반영
+    base_cohesion = a * 0.40 + e * 0.30 + (100.0 - t) * 0.10
+    sentiment_positive_bonus = sentiment.positive.confidence * 0.2
+    final_cohesion = base_cohesion + sentiment_positive_bonus
+
+    return MeetingRubrics(
+        dominance=int(round(min(100.0, max(0.0, final_dominance)))),
+        efficiency=int(round(min(100.0, max(0.0, final_efficiency)))),
+        cohesion=int(round(min(100.0, max(0.0, final_cohesion)))),
     )
 
 
@@ -647,10 +687,16 @@ async def run_analyze_pipeline(
         on_log=on_log,
     )
 
+    # [Rule-base Pipeline] 모든 지표를 조합하여 최종 루브릭 산출
+    rubric = calculate_final_rubrics(
+        topics=topics, sentiment=sentiment, emotion=emotion
+    )
+
     result = AnalyzeResponse(
         topic=topic_str,
         sentiment=sentiment,
         emotion=emotion,
+        rubric=rubric,
     )
     _record_log(
         request_id=resolved_request_id,

--- a/app/service/emotion_service.py
+++ b/app/service/emotion_service.py
@@ -42,7 +42,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -50,7 +54,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -58,7 +66,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -66,7 +78,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -74,7 +90,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -82,7 +102,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -90,7 +114,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -98,7 +126,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -122,7 +154,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -130,7 +166,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -138,7 +178,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -146,7 +190,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -154,7 +202,11 @@ INTEGRATED_EMOTION_JSON_SCHEMA: dict[str, Any] = {
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            "confidence": {"type": "number", "minimum": 0, "maximum": 100},
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 100,
+                            },
                         },
                         "required": ["confidence"],
                     },
@@ -364,7 +416,9 @@ def _convert_meeting_signals(raw_signals: _RawMeetingSignals) -> MeetingSignals:
             confidence=_to_score_int(raw_signals.tension.confidence, stage="inference"),
         ),
         alignment=MeetingSignalConfidenceValue(
-            confidence=_to_score_int(raw_signals.alignment.confidence, stage="inference"),
+            confidence=_to_score_int(
+                raw_signals.alignment.confidence, stage="inference"
+            ),
         ),
         urgency=MeetingSignalConfidenceValue(
             confidence=_to_score_int(raw_signals.urgency.confidence, stage="inference"),
@@ -449,7 +503,7 @@ async def extract_all_emotions_with_llm(
     base_emotions = _convert_base_emotions(raw_scores=parsed.emotions)
     meeting_signals = _convert_meeting_signals(raw_signals=parsed.meeting_signals)
     emerging_emotions = _normalize_emerging_emotions(raw_items=parsed.emerging_emotions)
-    
+
     return base_emotions, meeting_signals, emerging_emotions
 
 
@@ -464,7 +518,11 @@ async def classify_turn_emotion(request: TurnEmotionRequest) -> TurnEmotionRespo
             message="LLM configuration loading failed.",
         ) from exc
 
-    base_emotions, meeting_signals, emerging_emotions = await extract_all_emotions_with_llm(
+    (
+        base_emotions,
+        meeting_signals,
+        emerging_emotions,
+    ) = await extract_all_emotions_with_llm(
         client=client,
         deployment_name=llm_config.LLM_DEPLOYMENT_NAME,
         request=request,

--- a/app/types/mood.py
+++ b/app/types/mood.py
@@ -50,9 +50,24 @@ class AnalyzeSentiment(BaseModel):
         return self
 
 
+class MeetingRubrics(BaseModel):
+    """추출된 모든 지표를 조합하여 도출한 화자/발화 평가 루브릭."""
+
+    dominance: int = Field(
+        ge=0, le=100, description="주도성: 대화를 이끌고 영향을 미치는 정도"
+    )
+    efficiency: int = Field(
+        ge=0, le=100, description="효율성: 논의의 명확성 및 결론 도출 의지"
+    )
+    cohesion: int = Field(
+        ge=0, le=100, description="결속력: 합의 도출 및 팀 분위기 기여도"
+    )
+
+
 class AnalyzeResponse(BaseModel):
     """회의록 분석 응답 스키마."""
 
     topic: str
     sentiment: AnalyzeSentiment
     emotion: TurnEmotionResponse
+    rubric: MeetingRubrics

--- a/app/types/rubric.py
+++ b/app/types/rubric.py
@@ -1,0 +1,20 @@
+"""루브릭 지수 산출 요청/응답 타입 정의."""
+
+from pydantic import BaseModel, Field
+
+from app.types.emotion import MeetingSignals
+from app.types.mood import AnalyzeSentiment, MeetingRubrics
+
+
+class RubricCalculateRequest(BaseModel):
+    """루브릭 지수 산출 요청 스키마."""
+
+    topics: list[str] = Field(default_factory=list, description="추출된 주제 목록")
+    sentiment: AnalyzeSentiment = Field(..., description="추출된 감정 분포")
+    meeting_signals: MeetingSignals = Field(..., description="추출된 회의 시그널 (5축)")
+
+
+class RubricCalculateResponse(BaseModel):
+    """루브릭 지수 산출 응답 스키마."""
+
+    rubric: MeetingRubrics

--- a/tests/test_analyze_service.py
+++ b/tests/test_analyze_service.py
@@ -60,7 +60,7 @@ class _FakeCompletionsApi:
             and call_index == self.raise_on_call_index
         ):
             raise RuntimeError("upstream error")
-        
+
         # 힌트: 시스템 프롬프트의 고유 문구를 보고 적절한 응답을 선택한다
         msgs = kwargs.get("messages", [])
         system_content = ""
@@ -68,18 +68,22 @@ class _FakeCompletionsApi:
             if m.get("role") == "system":
                 system_content = m.get("content", "").lower()
                 break
-        
+
         if "sentiment distribution" in system_content:
-            return _FakeCompletion(content='{"sentiment":{"positive":{"confidence":62.5},"negative":{"confidence":12.5},"neutral":{"confidence":25.0}}}')
+            return _FakeCompletion(
+                content='{"sentiment":{"positive":{"confidence":62.5},"negative":{"confidence":12.5},"neutral":{"confidence":25.0}}}'
+            )
         if "concise meeting topics" in system_content:
             return _FakeCompletion(content='{"topics":["Architecture", "Budget"]}')
         if "meeting-specific signals" in system_content:
             return _FakeCompletion(content=_valid_emotion_payload())
-            
+
         if call_index < len(self.responses):
             return _FakeCompletion(content=self.responses[call_index])
-            
-        raise RuntimeError(f"response not prepared for system_content: {system_content[:50]}")
+
+        raise RuntimeError(
+            f"response not prepared for system_content: {system_content[:50]}"
+        )
 
 
 class _FakeChatApi:
@@ -157,20 +161,31 @@ async def test_run_analyze_pipeline_uses_fanout_and_token_limits(monkeypatch) ->
     client = _FakeClient(responses=[])
 
     monkeypatch.setattr(analyze_service, "get_llm_config", _mock_llm_config)
-    monkeypatch.setattr(analyze_service, "_build_azure_client", lambda llm_config: client)
+    monkeypatch.setattr(
+        analyze_service, "_build_azure_client", lambda llm_config: client
+    )
 
     response = await run_analyze_pipeline(request=_sample_request())
 
     assert response.result.topic == "Architecture, Budget"
     assert response.result.sentiment.positive.confidence == 63
     assert response.result.emotion.emotions.joy.confidence == 35
+    assert response.result.rubric.dominance >= 0
+    assert response.result.rubric.efficiency >= 0
+    assert response.result.rubric.cohesion >= 0
 
     assert len(client.chat.completions.calls) == 3
 
     # 호출별 토큰 제한 확인
-    topic_call = next(c for c in client.chat.completions.calls if "topics" in str(c).lower())
-    sentiment_call = next(c for c in client.chat.completions.calls if "sentiment" in str(c).lower())
-    emotion_call = next(c for c in client.chat.completions.calls if "signals" in str(c).lower())
+    topic_call = next(
+        c for c in client.chat.completions.calls if "topics" in str(c).lower()
+    )
+    sentiment_call = next(
+        c for c in client.chat.completions.calls if "sentiment" in str(c).lower()
+    )
+    emotion_call = next(
+        c for c in client.chat.completions.calls if "signals" in str(c).lower()
+    )
 
     assert topic_call["max_completion_tokens"] == TOPIC_MAX_OUTPUT_TOKENS
     assert sentiment_call["max_completion_tokens"] == SENTIMENT_MAX_OUTPUT_TOKENS
@@ -178,7 +193,9 @@ async def test_run_analyze_pipeline_uses_fanout_and_token_limits(monkeypatch) ->
 
 
 @pytest.mark.asyncio
-async def test_run_analyze_pipeline_executes_three_branches_in_parallel(monkeypatch) -> None:
+async def test_run_analyze_pipeline_executes_three_branches_in_parallel(
+    monkeypatch,
+) -> None:
     barrier = asyncio.Barrier(3)
 
     async def _wait_parallel_start(call_index: int) -> None:
@@ -190,7 +207,9 @@ async def test_run_analyze_pipeline_executes_three_branches_in_parallel(monkeypa
     )
 
     monkeypatch.setattr(analyze_service, "get_llm_config", _mock_llm_config)
-    monkeypatch.setattr(analyze_service, "_build_azure_client", lambda llm_config: client)
+    monkeypatch.setattr(
+        analyze_service, "_build_azure_client", lambda llm_config: client
+    )
 
     response = await run_analyze_pipeline(request=_sample_request())
     assert "Architecture" in response.result.topic
@@ -207,8 +226,10 @@ def test_preprocess_for_topic_removes_stopwords_and_keeps_keywords() -> None:
 @pytest.mark.asyncio
 async def test_extract_topics_with_llm_raises_on_non_json() -> None:
     fake_client = _FakeClient(responses=[])
+
     async def mock_create(**kwargs):
         return _FakeCompletion(content="not-json")
+
     fake_client.chat.completions.create = mock_create
 
     with pytest.raises(AnalyzeInferenceError) as exc_info:
@@ -224,8 +245,10 @@ async def test_extract_topics_with_llm_raises_on_non_json() -> None:
 @pytest.mark.asyncio
 async def test_extract_topics_with_llm_raises_on_empty_topics() -> None:
     fake_client = _FakeClient(responses=[])
+
     async def mock_create(**kwargs):
         return _FakeCompletion(content='{"topics":[]}')
+
     fake_client.chat.completions.create = mock_create
 
     with pytest.raises(AnalyzeInferenceError) as exc_info:
@@ -241,8 +264,12 @@ async def test_extract_topics_with_llm_raises_on_empty_topics() -> None:
 @pytest.mark.asyncio
 async def test_analyze_sentiment_with_llm_raises_on_schema_mismatch() -> None:
     fake_client = _FakeClient(responses=[])
+
     async def mock_create(**kwargs):
-        return _FakeCompletion(content='{"sentiment":{"positive":{"confidence":"bad"}}}')
+        return _FakeCompletion(
+            content='{"sentiment":{"positive":{"confidence":"bad"}}}'
+        )
+
     fake_client.chat.completions.create = mock_create
 
     with pytest.raises(AnalyzeInferenceError) as exc_info:
@@ -258,8 +285,10 @@ async def test_analyze_sentiment_with_llm_raises_on_schema_mismatch() -> None:
 @pytest.mark.asyncio
 async def test_analyze_emotion_with_llm_raises_on_schema_mismatch() -> None:
     fake_client = _FakeClient(responses=[])
+
     async def mock_create(**kwargs):
         return _FakeCompletion(content='{"emotions":{"anger":{"confidence":"bad"}}}')
+
     fake_client.chat.completions.create = mock_create
 
     with pytest.raises(AnalyzeInferenceError) as exc_info:
@@ -273,22 +302,29 @@ async def test_analyze_emotion_with_llm_raises_on_schema_mismatch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_analyze_pipeline_raises_when_sentiment_branch_fails(monkeypatch) -> None:
+async def test_run_analyze_pipeline_raises_when_sentiment_branch_fails(
+    monkeypatch,
+) -> None:
     client = _FakeClient(responses=[])
-    
+
     async def mock_create(**kwargs):
         msgs = kwargs.get("messages", [])
-        sys = next((m.get("content", "").lower() for m in msgs if m.get("role") == "system"), "")
+        sys = next(
+            (m.get("content", "").lower() for m in msgs if m.get("role") == "system"),
+            "",
+        )
         if "sentiment distribution" in sys:
             raise RuntimeError("upstream error")
         if "concise meeting topics" in sys:
             return _FakeCompletion(content='{"topics":["T"]}')
         return _FakeCompletion(content=_valid_emotion_payload())
-        
+
     client.chat.completions.create = mock_create
 
     monkeypatch.setattr(analyze_service, "get_llm_config", _mock_llm_config)
-    monkeypatch.setattr(analyze_service, "_build_azure_client", lambda llm_config: client)
+    monkeypatch.setattr(
+        analyze_service, "_build_azure_client", lambda llm_config: client
+    )
 
     with pytest.raises(AnalyzeInferenceError) as exc_info:
         await run_analyze_pipeline(request=_sample_request())
@@ -297,24 +333,33 @@ async def test_run_analyze_pipeline_raises_when_sentiment_branch_fails(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_run_analyze_pipeline_raises_when_emotion_branch_fails(monkeypatch) -> None:
+async def test_run_analyze_pipeline_raises_when_emotion_branch_fails(
+    monkeypatch,
+) -> None:
     client = _FakeClient(responses=[])
-    
+
     async def mock_create(**kwargs):
         msgs = kwargs.get("messages", [])
-        sys = next((m.get("content", "").lower() for m in msgs if m.get("role") == "system"), "")
+        sys = next(
+            (m.get("content", "").lower() for m in msgs if m.get("role") == "system"),
+            "",
+        )
         if "meeting-specific signals" in sys:
             raise RuntimeError("upstream error")
         if "concise meeting topics" in sys:
             return _FakeCompletion(content='{"topics":["T"]}')
         if "sentiment distribution" in sys:
-            return _FakeCompletion(content='{"sentiment":{"positive":{"confidence":50},"negative":{"confidence":25},"neutral":{"confidence":25}}}')
+            return _FakeCompletion(
+                content='{"sentiment":{"positive":{"confidence":50},"negative":{"confidence":25},"neutral":{"confidence":25}}}'
+            )
         return _FakeCompletion(content="{}")
-        
+
     client.chat.completions.create = mock_create
 
     monkeypatch.setattr(analyze_service, "get_llm_config", _mock_llm_config)
-    monkeypatch.setattr(analyze_service, "_build_azure_client", lambda llm_config: client)
+    monkeypatch.setattr(
+        analyze_service, "_build_azure_client", lambda llm_config: client
+    )
 
     with pytest.raises(AnalyzeInferenceError) as exc_info:
         await run_analyze_pipeline(request=_sample_request())

--- a/tests/test_emotion_service.py
+++ b/tests/test_emotion_service.py
@@ -17,11 +17,9 @@ from app.types.emotion import (
 async def test_classify_turn_emotion_calls_single_integrated_stage():
     # Given
     request = TurnEmotionRequest(
-        meeting_id="m1",
-        turn_id="t1",
-        utterance_text="테스트 문장입니다."
+        meeting_id="m1", turn_id="t1", utterance_text="테스트 문장입니다."
     )
-    
+
     mock_base = EmotionScores(
         anger=EmotionConfidenceValue(confidence=10),
         joy=EmotionConfidenceValue(confidence=20),
@@ -30,35 +28,37 @@ async def test_classify_turn_emotion_calls_single_integrated_stage():
         anxiety=EmotionConfidenceValue(confidence=0),
         frustration=EmotionConfidenceValue(confidence=0),
         excitement=EmotionConfidenceValue(confidence=0),
-        confusion=EmotionConfidenceValue(confidence=0)
+        confusion=EmotionConfidenceValue(confidence=0),
     )
-    
+
     mock_signals = MeetingSignals(
         tension=MeetingSignalConfidenceValue(confidence=10),
         alignment=MeetingSignalConfidenceValue(confidence=80),
         urgency=MeetingSignalConfidenceValue(confidence=20),
         clarity=MeetingSignalConfidenceValue(confidence=90),
-        engagement=MeetingSignalConfidenceValue(confidence=70)
+        engagement=MeetingSignalConfidenceValue(confidence=70),
     )
-    
-    mock_emerging = [
-        EmergingEmotion(label="relief", confidence=30)
-    ]
 
-    with patch("app.service.emotion_service.get_llm_config") as mock_get_config, \
-         patch("app.service.emotion_service._build_async_azure_client"), \
-         patch("app.service.emotion_service.extract_all_emotions_with_llm", new_callable=AsyncMock) as mock_extract:
-        
+    mock_emerging = [EmergingEmotion(label="relief", confidence=30)]
+
+    with (
+        patch("app.service.emotion_service.get_llm_config") as mock_get_config,
+        patch("app.service.emotion_service._build_async_azure_client"),
+        patch(
+            "app.service.emotion_service.extract_all_emotions_with_llm",
+            new_callable=AsyncMock,
+        ) as mock_extract,
+    ):
         mock_get_config.return_value.LLM_DEPLOYMENT_NAME = "gpt-4o"
         mock_extract.return_value = (mock_base, mock_signals, mock_emerging)
-        
+
         # When
         response = await classify_turn_emotion(request)
-        
+
         # Then
         assert response.emotions == mock_base
         assert response.meeting_signals == mock_signals
         assert response.emerging_emotions == mock_emerging
-        
+
         # 단일 호출 확인
         mock_extract.assert_awaited_once()

--- a/tests/test_rubric_api.py
+++ b/tests/test_rubric_api.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_calculate_rubric_endpoint_success():
+    # Given
+    payload = {
+        "topics": ["Architecture", "Performance"],
+        "sentiment": {
+            "positive": {"confidence": 60},
+            "negative": {"confidence": 10},
+            "neutral": {"confidence": 30},
+        },
+        "meeting_signals": {
+            "tension": {"confidence": 10},
+            "alignment": {"confidence": 80},
+            "urgency": {"confidence": 20},
+            "clarity": {"confidence": 90},
+            "engagement": {"confidence": 70},
+        },
+    }
+
+    # When
+    response = client.post("/api/v1/rubric/calculate", json=payload)
+
+    # Then
+    assert response.status_code == 200
+    data = response.json()
+    assert "rubric" in data
+    assert "dominance" in data["rubric"]
+    assert "efficiency" in data["rubric"]
+    assert "cohesion" in data["rubric"]
+
+    # 구체적인 값 검증 (calculate_final_rubrics 로직 기준)
+    # Dominance: (70*0.35 + 10*0.25 + 90*0.20 + 80*0.10 + 20*0.10) + (100-30)*0.1 = 55 + 7 = 62
+    assert data["rubric"]["dominance"] == 62
+
+    # Efficiency: (90*0.5 + 20*0.3 + 70*0.2) + min(2*5, 15) = 65 + 10 = 75
+    assert data["rubric"]["efficiency"] == 75
+
+    # Cohesion: (80*0.4 + 70*0.3 + 90*0.1) + 60*0.2 = (32 + 21 + 9) + 12 = 62 + 12 = 74
+    assert data["rubric"]["cohesion"] == 74
+
+
+def test_calculate_rubric_endpoint_invalid_payload():
+    # Given: 필수 필드 누락
+    payload = {"topics": []}
+
+    # When
+    response = client.post("/api/v1/rubric/calculate", json=payload)
+
+    # Then
+    assert response.status_code == 422


### PR DESCRIPTION
Implemented a dedicated rule-base pipeline for calculating 'Dominance', 'Efficiency', and 'Cohesion' indices by combining extracted topics, sentiment, and emotion signals. Added a standalone API for rubric calculation.